### PR TITLE
Make the header partial extensible.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,10 +1,10 @@
 <!doctype html>
 
-<html lang="{{ .Site.LanguageCode | default " en "}}">
+<html lang="{{ .Site.LanguageCode | default "en" }}">
 
 <head>
   <title>{{ .Site.Title }}</title>
-  {{ partial "meta" . -}}
+  {{ partial "meta" . }}
   {{ partial "header_includes" . -}}
 </head>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,57 +1,40 @@
 <!doctype html>
 
-<html lang="{{ .Site.LanguageCode | default "en"}}">
+<html lang="{{ .Site.LanguageCode | default " en "}}">
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{{ .Site.Title }}</title>
-    <meta name="description" content="The HTML5 Herald">
-    <meta name="author" content="{{ .Site.Author.name }}">
-    {{ .Hugo.Generator }}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/7.0.0/normalize.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Slab|Ruda" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="{{ "css/styles.css" | relURL}}" />
+  <title>{{ .Site.Title }}</title>
+  {{ partial "meta" . -}}
+  {{ partial "header_includes" . -}}
 </head>
 
 <body>
-    <div id="container">
-        <header>
-            <h1>
+  <div id="container">
+    <header>
+      <h1>
                 <a href="{{ relURL "/" }}">{{ .Site.Title | markdownify }}</a>
             </h1>
 
-            <ul id="social-media">
-                {{ if .Site.Author.twitter }}
-                <li><a href="https://twitter.com/{{ .Site.Author.twitter }}"><i class="fa fa-twitter fa-lg" aria-hidden="true"></i></a></li>
-                {{ end }}
-        
-                {{ if .Site.Author.linkedin }}
-                <li><a href="https://www.linkedin.com/in/{{ .Site.Author.linkedin }}"><i class="fa fa-linkedin fa-lg" aria-hidden="true"></i></a></li>
-                {{ end }}
-        
-                {{ if .Site.Author.github }}
-                <li><a href="https://github.com/{{ .Site.Author.github }}"><i class="fa fa-github fa-lg" aria-hidden="true"></i></a></li>
-                {{ end }}
-        
-                {{ if .Site.Author.gitlab }}
-                <li><a href="https://gitlab.com/{{ .Site.Author.gitlab }}"><i class="fa fa-gitlab fa-lg" aria-hidden="true"></i></a></li>
-                {{ end }}
-        
-                {{ if .Site.Author.facebook }}
-                <li><a href="https://www.facebook.com/{{ .Site.Author.facebook }}"><i class="fa fa-facebook fa-lg" aria-hidden="true"></i></a></li>
-                {{ end }}
-        
-                {{ if .Site.Author.instagram }}
-                <li><a href="https://instagram.com/{{ .Site.Author.instagram }}"><i class="fa fa-instagram fa-lg" aria-hidden="true"></i></a></li>
-                {{ end }}
-            </ul>
-            {{ with .Site.Params.tagline }}
-            <p><em>{{ . | markdownify }}</em></p>
-            {{ end }}
-        </header>
+      <ul id="social-media">
+        {{ if .Site.Author.twitter }}
+        <li><a href="https://twitter.com/{{ .Site.Author.twitter }}"><i class="fa fa-twitter fa-lg" aria-hidden="true"></i></a></li>
+        {{ end }} {{ if .Site.Author.linkedin }}
+        <li><a href="https://www.linkedin.com/in/{{ .Site.Author.linkedin }}"><i class="fa fa-linkedin fa-lg" aria-hidden="true"></i></a></li>
+        {{ end }} {{ if .Site.Author.github }}
+        <li><a href="https://github.com/{{ .Site.Author.github }}"><i class="fa fa-github fa-lg" aria-hidden="true"></i></a></li>
+        {{ end }} {{ if .Site.Author.gitlab }}
+        <li><a href="https://gitlab.com/{{ .Site.Author.gitlab }}"><i class="fa fa-gitlab fa-lg" aria-hidden="true"></i></a></li>
+        {{ end }} {{ if .Site.Author.facebook }}
+        <li><a href="https://www.facebook.com/{{ .Site.Author.facebook }}"><i class="fa fa-facebook fa-lg" aria-hidden="true"></i></a></li>
+        {{ end }} {{ if .Site.Author.instagram }}
+        <li><a href="https://instagram.com/{{ .Site.Author.instagram }}"><i class="fa fa-instagram fa-lg" aria-hidden="true"></i></a></li>
+        {{ end }}
+      </ul>
+      {{ with .Site.Params.tagline }}
+      <p><em>{{ . | markdownify }}</em></p>
+      {{ end }}
+    </header>
 
-        {{ partial "nav" . }}
-        
-        <main>
+    {{ partial "nav" . }}
+
+    <main>

--- a/layouts/partials/header_includes.html
+++ b/layouts/partials/header_includes.html
@@ -1,0 +1,4 @@
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/7.0.0/normalize.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Slab|Ruda" />
+  <link rel="stylesheet" type="text/css" href="{{ "css/styles.css" | relURL}}" />

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,0 +1,5 @@
+<meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="{{ .Site.Params.description | default "The HTML5 Herald" }}" />
+  <meta name="author" content="{{ .Params.Author | default .Site.Author.name }}" />
+  {{ .Hugo.Generator -}}


### PR DESCRIPTION
This change makes the header partial a bit more extensible, somewhat along the lines of the example at https://gohugo.io/templates/partials/#example-header-html.

A couple other tweaks snuck into the template:

* Make the meta description configurable, defaulting to the hard-coded description in place.
* Allow individual pages to override the meta author name.
* Consistent use of a closing slash for head elements.