### PR TITLE
Make the single partial extensible.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,35 +1,6 @@
 {{ define "main" }}
 
-<article>
-
-    <h1>{{ .Title }}</h1>
-
-    {{ if not .Params.meta }}
-        {{ partial "aside" . }}
-    {{ end }}
-
-    {{.Content}}
-
-</article>
-
-{{ if not .Params.meta }}
-<section class="post-nav">
-    <ul>
-        {{ with .PrevInSection }}
-        <li>
-            <a href="{{.Permalink}}"><i class="fa fa-chevron-circle-left"></i> {{ .Title }}</a>
-        </li>
-        {{ end }}
-        {{ with .NextInSection }}
-        <li>
-            <a href="{{.Permalink}}">{{ .Title }} <i class="fa fa-chevron-circle-right"></i> </a>
-        </li>
-        {{ end }}
-    </ul>
-</section>
-    {{ if .Site.DisqusShortname }}
-        {{ partial "disqus" . }}
-    {{ end }}
-{{ end }}
+{{ partial "article" . }}
+{{ partial "single_footer" . }}
 
 {{ end }}

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,0 +1,11 @@
+<article>
+
+    <h1>{{ .Title }}</h1>
+
+    {{ if not .Params.meta }}
+        {{ partial "aside" . }}
+    {{ end }}
+
+    {{.Content}}
+
+</article>

--- a/layouts/partials/single_footer.html
+++ b/layouts/partials/single_footer.html
@@ -1,0 +1,19 @@
+{{ if not .Params.meta }}
+<section class="post-nav">
+    <ul>
+        {{ with .PrevInSection }}
+        <li>
+            <a href="{{.Permalink}}"><i class="fa fa-chevron-circle-left"></i> {{ .Title }}</a>
+        </li>
+        {{ end }}
+        {{ with .NextInSection }}
+        <li>
+            <a href="{{.Permalink}}">{{ .Title }} <i class="fa fa-chevron-circle-right"></i> </a>
+        </li>
+        {{ end }}
+    </ul>
+</section>
+    {{ if .Site.DisqusShortname }}
+        {{ partial "disqus" . }}
+    {{ end }}
+{{ end }}


### PR DESCRIPTION
This splits the single partial into a primary article and a footer template. They seem like things that would be customized at different times to different purposes, and it may well be that the single_footer partial could become more generic.