### PR TITLE
Fix RSS link

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
     <footer>
         <h6>{{ .Site.Copyright | markdownify }} | 
             Rendered by <a href="https://gohugo.io" title="Hugo">Hugo</a> |
-            <a href="{{.Site.BaseURL}}index.xml">Subscribe</a></h6>
+            <a href="{{ .RSSLink }}">Subscribe</a></h6>
     </footer>
 </div>
 <script src="{{ "js/scripts.js" | relURL }}"></script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,8 +1,11 @@
 </main>
     <footer>
         <h6>{{ .Site.Copyright | markdownify }} | 
-            Rendered by <a href="https://gohugo.io" title="Hugo">Hugo</a> |
-            <a href="{{ .RSSLink }}">Subscribe</a></h6>
+            Rendered by <a href="https://gohugo.io" title="Hugo">Hugo</a>
+            {{ if .RSSLink }}
+		     | <a href="{{ .RSSLink }}">Subscribe</a>
+	        {{ end }}
+        </h6>
     </footer>
 </div>
 <script src="{{ "js/scripts.js" | relURL }}"></script>


### PR DESCRIPTION
if you specify [outputFormats.RSS] - baseName, the RSS file may not be the default index.xml, use hugo builtin `.RSSLink` param instead.