### PR TITLE
Disqus section can be disabled

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,3 +1,4 @@
+{{ if not .Params.disableComments }}
 <section class="comments-block">
       <button id="show-comments" style="display: none;"><i class="fa fa-comments-o"></i> Add/View Comments</button>
 </section>
@@ -50,3 +51,4 @@
             }
       })();
 </script>
+{{ end }}


### PR DESCRIPTION
Disqus section can be disabled for a given post using the new disableComments property

just add the following to the front matter:

```yaml
disableComments: true
```

Love the theme!

Hope it helps!