### PR TITLE
SEO: Fixing Title so it uses the Page Title when available

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
 <html lang="{{ .Site.LanguageCode | default "en" }}">
 
 <head>
-  <title>{{ .Site.Title }}</title>
+  <title>{{ if .Page.Title }}{{ .Page.Title }} - {{ end }}{{ .Site.Title }}</title>
   {{ partial "meta" . }}
   {{ partial "header_includes" . -}}
 </head>


### PR DESCRIPTION
If a Page title is available this PR uses it instead of the global site title, helping with SEO.